### PR TITLE
Fix JWT corruption not automatically recovering on first request

### DIFF
--- a/src/arango_crud/auths.py
+++ b/src/arango_crud/auths.py
@@ -406,7 +406,6 @@ class JWTAuth(StatefulAuth):
         will consider refreshing it."""
         if self._token is None:
             self.try_load_or_refresh_token(config)
-            return
 
         if self._token.expires_at_utc_seconds < time.time() + 60:
             self.force_refresh_token(config)

--- a/src/arango_crud/auths.py
+++ b/src/arango_crud/auths.py
@@ -384,8 +384,8 @@ class JWTAuth(StatefulAuth):
 
         _token (JWTToken, None): The current token we are authenticating with,
             if we have a token.
-        _forcing_refresh (bool): True if we are going to skip the cache for the
-            next refresh, false otherwise.
+        _forcing_refresh (str, None): Only set if we have a particular JWT token
+            which we are not satisfied with. Otherwise, None.
     """
     def __init__(self, username, password, cache):
         """Initializes authorization to use the given cache in the future. Does
@@ -401,7 +401,7 @@ class JWTAuth(StatefulAuth):
         self.password = password if password is not None else ''
         self.cache = cache
         self._token = None
-        self._forcing_refresh = False
+        self._forcing_refresh = None
 
     def prepare(self, config):
         """If this has no token in memory it will attempt to acquire one (first
@@ -423,8 +423,8 @@ class JWTAuth(StatefulAuth):
         """If this has an active token it will be cleared and this will return
         True. Otherwise this will return False."""
         if self._token is not None:
+            self._forcing_refresh = self._token.token
             self._token = None
-            self._forcing_refresh = True
             return True
         return False
 
@@ -453,10 +453,10 @@ class JWTAuth(StatefulAuth):
             return
 
         for i in range(math.ceil(self.cache.lock_time_seconds / 10.0)):
-            if not self._forcing_refresh:
-                self._token = self.cache.fetch()
-                if self._token is not None:
-                    return
+            self._token = self.cache.fetch()
+            if self._token is not None and self._forcing_refresh != self._token.token:
+                return
+            self._token = None
             if self.cache.try_acquire_lock():
                 break
             time.sleep(0.1)

--- a/src/arango_crud/auths.py
+++ b/src/arango_crud/auths.py
@@ -464,7 +464,7 @@ class JWTAuth(StatefulAuth):
         token = self.create_jwt_token(config)
         self.cache.try_set(token)
         self._token = token
-        self._forcing_refresh = False
+        self._forcing_refresh = None
 
     def try_refresh_token(self, config):
         """Attempts to refresh the token. This will do nothing if we fail to

--- a/src/setup.py
+++ b/src/setup.py
@@ -5,7 +5,7 @@ with open("../README.md", "r") as fh:   # pragma: no cover
 
 setuptools.setup(   # pragma: no cover
     name="arango_crud",
-    version="1.0.2",
+    version="1.0.3",
     author="Timothy Moore",
     author_email="mtimothy984+pypi@gmail.com",
     description="A wrapper around ArangoDB CRUD HTTP API",

--- a/tests/test_auth_jwt.py
+++ b/tests/test_auth_jwt.py
@@ -213,22 +213,22 @@ class Test(unittest.TestCase):
         token = jwt_auth._token  # noqa
         self.assertIsNotNone(token)
 
-        token.token += 'corruption'
-        self.assertTrue(token.token.endswith('corruption'))
+        token.token = 'corruption'
+        self.assertEqual(token.token, 'corruption')
         self.assertTrue(jwt_auth.cache.try_set(token))
-        self.assertTrue(token.token.endswith('corruption'))
+        self.assertEqual(token.token, 'corruption')
 
         cfg = create_config()
         cfg.prepare()
 
         token = cfg.auth.delegate._token  # noqa
-        self.assertTrue(token.token.endswith('corruption'))
+        self.assertEqual(token.token, 'corruption')
 
         db = cfg.database(helper.TEST_ARANGO_DB)
         self.assertFalse(db.check_if_exists())
 
         token = cfg.auth.delegate._token  # noqa
-        self.assertFalse(token.token.endswith('corruption'))
+        self.assertEqual(token.token, 'corruption')
 
         os.remove('test.jwt')
         if os.path.exists('test.jwt.lock'):

--- a/tests/test_auth_jwt.py
+++ b/tests/test_auth_jwt.py
@@ -219,8 +219,14 @@ class Test(unittest.TestCase):
         cfg = create_config()
         cfg.prepare()
 
+        token = cfg.auth.delegate._token  # noqa
+        self.assertTrue(token.token.endswith('corruption'))
+
         db = cfg.database(helper.TEST_ARANGO_DB)
         self.assertFalse(db.check_if_exists())
+
+        token = cfg.auth.delegate._token  # noqa
+        self.assertFalse(token.token.endswith('corruption'))
 
         os.remove('test.jwt')
         if os.path.exists('test.jwt.lock'):

--- a/tests/test_auth_jwt.py
+++ b/tests/test_auth_jwt.py
@@ -214,7 +214,9 @@ class Test(unittest.TestCase):
         self.assertIsNotNone(token)
 
         token.token += 'corruption'
+        self.assertTrue(token.token.endswith('corruption'))
         self.assertTrue(jwt_auth.cache.try_set(token))
+        self.assertTrue(token.token.endswith('corruption'))
 
         cfg = create_config()
         cfg.prepare()

--- a/tests/test_auth_jwt.py
+++ b/tests/test_auth_jwt.py
@@ -178,6 +178,54 @@ class Test(unittest.TestCase):
         os.remove('test.jwt')
         os.remove('test.jwt.lock')
 
+    def test_resets_jwt_on_first_load_if_bad(self):
+        self.assertFalse(os.path.exists('test.jwt'))
+        self.assertFalse(os.path.exists('test.jwt.lock'))
+
+        def create_config():
+            return Config(
+                cluster=RandomCluster(urls=helper.TEST_CLUSTER_URLS),
+                timeout_seconds=10,
+                back_off=StepBackOffStrategy(steps=[1]),
+                ttl_seconds=None,
+                auth=JWTAuth(
+                    username=helper.TEST_USERNAME,
+                    password=helper.TEST_PASSWORD,
+                    cache=JWTDiskCache(
+                        lock_file='test.jwt.lock',
+                        lock_time_seconds=10,
+                        store_file='test.jwt'
+                    )
+                )
+            )
+
+        cfg = create_config()
+        cfg.prepare()
+
+        self.assertTrue(os.path.exists('test.jwt'))
+
+        # This is a little bit of private implementation, but we're essentially
+        # trying to corrupt the JWT which is not something we exposed...
+
+        jwt_auth = cfg.auth.delegate
+        self.assertIsNotNone(jwt_auth)
+
+        token = jwt_auth._token  # noqa
+        self.assertIsNotNone(token)
+
+        token.token += 'corruption'
+        self.assertTrue(jwt_auth.cache.try_set(token))
+
+        cfg = create_config()
+        cfg.prepare()
+
+        db = cfg.database(helper.TEST_ARANGO_DB)
+        self.assertFalse(db.check_if_exists())
+
+        os.remove('test.jwt')
+        if os.path.exists('test.jwt.lock'):
+            os.remove('test.jwt.lock')
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/tests/test_auth_jwt.py
+++ b/tests/test_auth_jwt.py
@@ -223,13 +223,11 @@ class Test(unittest.TestCase):
 
         token = cfg.auth.delegate._token  # noqa
         self.assertEqual(token.token, 'corruption')
-
         db = cfg.database(helper.TEST_ARANGO_DB)
         self.assertFalse(db.check_if_exists())
 
         token = cfg.auth.delegate._token  # noqa
-        self.assertEqual(token.token, 'corruption')
-
+        self.assertNotEqual(token.token, 'corruption')
         os.remove('test.jwt')
         if os.path.exists('test.jwt.lock'):
             os.remove('test.jwt.lock')


### PR DESCRIPTION
This fixes JWT corruption and expiration not recovering on the first request if they were being loaded from a disk cache, since although it properly cleared the token the first time around, it just immediately loaded the exact same token. It will now detect if it just got the exact same token and if so it will disregard it.

This will require at most one refresh per token, even in parallel contexts, when the disk cache corrupted.